### PR TITLE
Add "when" as an option to respond in the form of a question

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you'd rather do it manually, then just clone this repo, set up a Heroku app w
 ## Usage
 
 * `trebekbot jeopardy me`: starts a round of Jeopardy! trebekbot will pick a category and score for you.
-* `trebekbot what/who is/are [answer]`: sends an answer. Remember, responses must be in the form of a question!
+* `trebekbot what/who/where/when is/are [answer]`: sends an answer. Remember, responses must be in the form of a question!
 * `trebekbot what's my score`: shows your current score.
 * `trebekbot show the leaderboard`: shows the current top scores.
 * `trebekbot show the loserboard`: shows the current bottom scores.

--- a/app.rb
+++ b/app.rb
@@ -193,7 +193,7 @@ end
 # (I don't care if there's no question mark)
 # 
 def is_question_format?(answer)
-  answer.gsub(/[^\w\s]/i, "").match(/^(what|whats|where|wheres|who|whos) /i)
+  answer.gsub(/[^\w\s]/i, "").match(/^(what|whats|where|wheres|who|whos|when|whens) /i)
 end
 
 # Checks if the user answer matches the correct answer.
@@ -428,7 +428,7 @@ end
 def respond_with_help
   reply = <<help
 Type `#{ENV["BOT_USERNAME"]} jeopardy me` to start a new round of Slack Jeopardy. I will pick the category and price. Anyone in the channel can respond.
-Type `#{ENV["BOT_USERNAME"]} [what|where|who] [is|are] [answer]?` to respond to the active round. You have #{ENV["SECONDS_TO_ANSWER"]} seconds to answer. Remember, responses must be in the form of a question, e.g. `#{ENV["BOT_USERNAME"]} what is dirt?`.
+Type `#{ENV["BOT_USERNAME"]} [what|where|who|where] [is|are] [answer]?` to respond to the active round. You have #{ENV["SECONDS_TO_ANSWER"]} seconds to answer. Remember, responses must be in the form of a question, e.g. `#{ENV["BOT_USERNAME"]} what is dirt?`.
 Type `#{ENV["BOT_USERNAME"]} what is my score` to see your current score.
 Type `#{ENV["BOT_USERNAME"]} show the leaderboard` to see the top scores.
 Type `#{ENV["BOT_USERNAME"]} show the loserboard` to see the bottom scores.

--- a/app.rb
+++ b/app.rb
@@ -428,7 +428,7 @@ end
 def respond_with_help
   reply = <<help
 Type `#{ENV["BOT_USERNAME"]} jeopardy me` to start a new round of Slack Jeopardy. I will pick the category and price. Anyone in the channel can respond.
-Type `#{ENV["BOT_USERNAME"]} [what|where|who|where] [is|are] [answer]?` to respond to the active round. You have #{ENV["SECONDS_TO_ANSWER"]} seconds to answer. Remember, responses must be in the form of a question, e.g. `#{ENV["BOT_USERNAME"]} what is dirt?`.
+Type `#{ENV["BOT_USERNAME"]} [what|where|who|when] [is|are] [answer]?` to respond to the active round. You have #{ENV["SECONDS_TO_ANSWER"]} seconds to answer. Remember, responses must be in the form of a question, e.g. `#{ENV["BOT_USERNAME"]} what is dirt?`.
 Type `#{ENV["BOT_USERNAME"]} what is my score` to see your current score.
 Type `#{ENV["BOT_USERNAME"]} show the leaderboard` to see the top scores.
 Type `#{ENV["BOT_USERNAME"]} show the loserboard` to see the bottom scores.


### PR DESCRIPTION
When responding in the form of a question, previously the only options were "what," "where," and "who." I added "when" to fix issue https://github.com/gesteves/trebekbot/issues/10
