### PR TITLE
Fixed error due to #any? no longer working on Strings

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -120,7 +120,7 @@ def get_question
   puts "[LOG] #{request.body}"
   response = JSON.parse(request.body).first
   question = response["question"]
-  if question.nil? || question.strip == "" || ENV["QUESTION_SUBSTRING_BLACKLIST"].any? { |phrase| question.include?(phrase) }
+  if question.nil? || question.strip == "" || ENV["QUESTION_SUBSTRING_BLACKLIST"].split(",").any? { |phrase| question.include?(phrase) }
     response = get_question
   end
   response["value"] = 200 if response["value"].nil?


### PR DESCRIPTION
Ruby Strings were Enumerable in 1.8, but aren't anymore, so the #any? method was causing an error.
Split the string first and now it works.