### PR TITLE
Fix QUESTION_SUBSTRING_BLACKLIST default value

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,10 +44,7 @@
     "QUESTION_SUBSTRING_BLACKLIST": {
       "description": "Comma-separated list of strings which indicate a question containing any of these should be ignored.",
       "required": false,
-      "value": [
-        "seen here",
-        "[audio clue]"
-      ]
+      "value": "seen here,[audio clue]"
     }
   }
 }


### PR DESCRIPTION
See https://devcenter.heroku.com/articles/app-json-schema#env

> `value`: a default value to use. This should always be a string.

This was causing the `Deploy to Heroku` button/site to fail silently (unless you checked the Network debugger)